### PR TITLE
Stop remote homekit light/door commands from tripping manual recovery

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -883,7 +883,11 @@ void comms_loop_sec2()
             case PacketCommand::Light:
             {
                 bool l = garage_door.light;
-                manual_recovery();
+                if (pkt.m_data.value.light.light == LightState::Toggle ||
+                    pkt.m_data.value.light.light == LightState::Toggle2)
+                {
+                    manual_recovery();
+                }
                 switch (pkt.m_data.value.light.light)
                 {
                 case LightState::Off:
@@ -947,7 +951,8 @@ void comms_loop_sec2()
             case PacketCommand::DoorAction:
             {
                 RINFO(TAG, "Door Action");
-                if (pkt.m_data.value.door_action.pressed)
+                if (pkt.m_data.value.door_action.pressed &&
+                    pkt.m_data.value.door_action.action == DoorAction::Toggle)
                 {
                     manual_recovery();
                 }


### PR DESCRIPTION
## Summary

`manual_recovery()` was misfiring due to automation traffic.  
Every light or door-action command (including HomeKit On/Off) incremented the recovery counter, so a few rapid automation events could trigger soft-AP recovery unexpectedly.

---

### Root Cause

- All light packets (`On`, `Off`, `Toggle`, `Toggle2`) and door actions incremented the recovery counter.  
- Remote or automated commands were treated the same as physical button presses.

---

### Fix

- Only physical `Toggle` / `Toggle2` light packets now count toward manual recovery.  
- Door actions only increment the counter on a physical `Toggle` press — `Open`, `Close`, and `Stop` are ignored.  
- Remote automation traffic no longer affects recovery logic.

---

### Impact

- Prevents unintended recovery mode triggered by HomeKit or automations.  
- Keeps manual recovery functional for actual button-mash scenarios.  
- No user-facing or configuration changes.
