### PR TITLE
Fix/enhancement: Hardwired Sec+ GPIO Controls Mirror Wall Panel, Opti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ For Dry Contact door protocol, set the sensor debounce duration. When the door o
 
 ### Enable hardwired open/close control
 
-For Security+ 1.0 and Security +2.0 it is possible to repurpose the sensors used for dry-contact door open / close to buttons that trigger a door open / close action. Select this check box to enable this option.
+For Security+ 1.0 and Security +2.0 it is possible to repurpose the sensors used for dry-contact door open / close to buttons that trigger a door open / close action. Select this check box to enable this option. When both the open and close GPIOs are tied together with a jumper (or wired to the same button), the inputs behave exactly like the factory wall control: a toggle from a fully open/closed door starts travel in the opposite direction, a toggle while moving pauses the door, and a follow-up toggle from that paused state makes the door reverse direction.
+
+When enabled, an additional option appears to **Bypass time-to-close delay for hardwired controls**. Use this when the open/close GPIOs are wired to a physical wall button and you want that button to behave like the native door control panel. When checked, any close or toggle action that comes from the hardwired inputs will ignore the configured Time-To-Close warning delay so the door responds immediately, while HomeKit, automations, or remotes continue to respect the delay.
 
 ### Use software serial emulation rather than h/w UART _(ratgdo32 boards only)_
 

--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -2588,7 +2588,7 @@ void delayFnCall(uint32_t ms, void (*callback)())
                        });
 }
 
-GarageDoorCurrentState close_door()
+GarageDoorCurrentState close_door(bool bypass_ttc)
 {
     if (garage_door.current_state == GarageDoorCurrentState::CURR_CLOSED)
     {
@@ -2609,8 +2609,20 @@ GarageDoorCurrentState close_door()
         return GarageDoorCurrentState::CURR_STOPPED;
     }
 
-    if (userConfig->getTTCseconds() == 0)
+    if (bypass_ttc && TTCtimer.active())
     {
+        ESP_LOGI(TAG, "Canceling TTC delay timer for hardwired control");
+        TTCtimer.detach();
+        set_light(TTCwasLightOn);
+    }
+
+    bool immediateClose = (userConfig->getTTCseconds() == 0) || bypass_ttc;
+    if (immediateClose)
+    {
+        if (bypass_ttc && userConfig->getTTCseconds() != 0)
+        {
+            ESP_LOGI(TAG, "Bypassing time-to-close delay for hardwired control");
+        }
         ESP_LOGI(TAG, "Closing door");
         door_command_close();
     }
@@ -2647,6 +2659,33 @@ GarageDoorCurrentState close_door()
     }
     return GarageDoorCurrentState::CURR_CLOSING;
 }
+
+#if defined(ESP8266) || !defined(USE_GDOLIB)
+GarageDoorCurrentState toggle_door(bool bypass_ttc)
+{
+    ESP_LOGI(TAG, "Toggling door via hardwired control");
+    if (doorControlType == 3)
+    {
+        ESP_LOGW(TAG, "Toggle requested in dry contact mode; ignored");
+        return garage_door.current_state;
+    }
+
+    if (TTCtimer.active())
+    {
+        ESP_LOGI(TAG, "Canceling TTC delay timer prior to toggle");
+        TTCtimer.detach();
+        set_light(TTCwasLightOn);
+    }
+
+    if (bypass_ttc && userConfig->getTTCseconds() != 0)
+    {
+        ESP_LOGI(TAG, "Bypassing time-to-close delay for hardwired toggle");
+    }
+
+    door_command(DoorAction::Toggle);
+    return garage_door.current_state;
+}
+#endif
 
 #ifndef USE_GDOLIB
 void send_get_status()

--- a/src/comms.h
+++ b/src/comms.h
@@ -22,7 +22,10 @@ extern void shutdown_comms();
 extern void comms_loop();
 
 extern GarageDoorCurrentState open_door();
-extern GarageDoorCurrentState close_door();
+extern GarageDoorCurrentState close_door(bool bypass_ttc = false);
+#if defined(ESP8266) || !defined(USE_GDOLIB)
+extern GarageDoorCurrentState toggle_door(bool bypass_ttc = false);
+#endif
 extern void delayFnCall(uint32_t ms, void (*callback)());
 #ifndef USE_GDOLIB
 extern void send_get_status();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -367,6 +367,7 @@ userSettings::userSettings()
         {cfg_syslogFacility, {false, false, SYSLOG_LOCAL0, helperSyslogFacility}}, // call fn to set global
         {cfg_logLevel, {false, false, ESP_LOG_INFO, helperLogLevel}},              // call fn to set log level
         {cfg_dcOpenClose, {true, false, false, NULL}},
+        {cfg_dcBypassTTC, {false, false, false, NULL}},
         {cfg_dcDebounceDuration, {true, false, 50, NULL}},
         {cfg_obstFromStatus, {true, false, false, NULL}},
 #ifdef RATGDO32_DISCO

--- a/src/config.h
+++ b/src/config.h
@@ -82,6 +82,7 @@ constexpr char cfg_syslogPort[] PROGMEM = "syslogPort";
 constexpr char cfg_syslogFacility[] PROGMEM = "syslogFacility";
 constexpr char cfg_logLevel[] PROGMEM = "logLevel";
 constexpr char cfg_dcOpenClose[] PROGMEM = "dcOpenClose";
+constexpr char cfg_dcBypassTTC[] PROGMEM = "dcBypassTTC";
 constexpr char cfg_dcDebounceDuration[] PROGMEM = "dcDebounceDuration";
 constexpr char cfg_useSWserial[] PROGMEM = "useSWserial";
 constexpr char cfg_obstFromStatus[] PROGMEM = "obstFromStatus";
@@ -187,6 +188,7 @@ public:
     uint32_t getSyslogFacility() { return std::get<int>(get(cfg_syslogFacility)); };
     uint32_t getLogLevel() { return std::get<int>(get(cfg_logLevel)); };
     bool getDCOpenClose() { return std::get<bool>(get(cfg_dcOpenClose)); };
+    bool getDCBypassTTC() { return std::get<bool>(get(cfg_dcBypassTTC)); };
     uint32_t getDCDebounceDuration() { return std::get<int>(get(cfg_dcDebounceDuration)); };
     bool getObstFromStatus() { return std::get<bool>(get(cfg_obstFromStatus)); };
     uint32_t getBuiltInTTC() { return std::get<int>(get(cfg_builtInTTC)); };

--- a/src/drycontact.cpp
+++ b/src/drycontact.cpp
@@ -112,16 +112,27 @@ void drycontact_loop()
     {
         // Dry contacts are repurposed as optional door open/close when we
         // are using Sec+ 1.0 or Sec+ 2.0 door control type
-        if (dryContactDoorOpen)
+        bool bypassTTC = userConfig->getDCBypassTTC();
+        if (dryContactDoorOpen && dryContactDoorClose)
         {
-            open_door();
+            ESP_LOGI(TAG, "Hardwired toggle requested");
+            toggle_door(bypassTTC);
             dryContactDoorOpen = false;
-        }
-
-        if (dryContactDoorClose)
-        {
-            close_door();
             dryContactDoorClose = false;
+        }
+        else
+        {
+            if (dryContactDoorOpen)
+            {
+                open_door();
+                dryContactDoorOpen = false;
+            }
+
+            if (dryContactDoorClose)
+            {
+                close_door(bypassTTC);
+                dryContactDoorClose = false;
+            }
         }
 
         if (dryContactLightToggle)

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -770,6 +770,7 @@ void build_status_json(char *json)
     const char *tz = userConfig->getTimeZone();
     JSON_ADD_STR(cfg_timeZone, (tz && strlen(tz) > 0) ? tz : "Etc/UTC;UTC0");
     JSON_ADD_BOOL(cfg_dcOpenClose, userConfig->getDCOpenClose());
+    JSON_ADD_BOOL(cfg_dcBypassTTC, userConfig->getDCBypassTTC());
     JSON_ADD_BOOL(cfg_obstFromStatus, userConfig->getObstFromStatus());
     JSON_ADD_INT(cfg_dcDebounceDuration, userConfig->getDCDebounceDuration());
     JSON_ADD_STR("qrPayload", qrPayload);

--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -150,6 +150,13 @@ function toggleDCOpenClose(radio) {
     }
     document.getElementById("obstFromStatusRow").style.display = (value != 3) ? "table-row" : "none";
     document.getElementById("dcDebounceDurationRow").style.display = (value == 3) ? "table-row" : "none";
+    toggleHardwiredBypassRow();
+}
+
+function toggleHardwiredBypassRow() {
+    const supportsHardwired = !document.getElementById("gdodrycontact").checked;
+    const hardwiredEnabled = document.getElementById("dcOpenClose").checked;
+    document.getElementById("dcBypassTTCRow").style.display = (supportsHardwired && hardwiredEnabled) ? "table-row" : "none";
 }
 
 // enable laser
@@ -345,6 +352,7 @@ function setElementsFromStatus(status) {
                 document.getElementById("obstFromStatusRow").style.display = (value != 3) ? "table-row" : "none";
                 document.getElementById("dcDebounceDurationRow").style.display = (value == 3) ? "table-row" : "none";
                 document.getElementById("motionMotion").disabled = (value == 2) ? false : true;
+                toggleHardwiredBypassRow();
                 break;
             case "pinBasedObst":
                 document.getElementById(key).innerHTML = (value == true) ? "&nbsp;(Pin-based)" : "&nbsp;(Message)";
@@ -416,10 +424,17 @@ function setElementsFromStatus(status) {
                 break;
             case "laserHomeKit":
             case "vehicleHomeKit":
-            case "dcOpenClose":
             case "useSWserial":
             case "obstFromStatus":
                 document.getElementById(key).checked = value;
+                break;
+            case "dcOpenClose":
+                document.getElementById(key).checked = value;
+                toggleHardwiredBypassRow();
+                break;
+            case "dcBypassTTC":
+                document.getElementById(key).checked = value;
+                toggleHardwiredBypassRow();
                 break;
             case "TTClight":
                 document.getElementById(key).checked = value;
@@ -1207,6 +1222,7 @@ async function saveSettings() {
     const laserEnabled = (document.getElementById("laserEnabled").checked) ? '1' : '0';
     const laserHomeKit = (document.getElementById("laserHomeKit").checked) ? '1' : '0';
     const dcOpenClose = (document.getElementById("dcOpenClose").checked) ? '1' : '0';
+    const dcBypassTTC = (document.getElementById("dcBypassTTC").checked) ? '1' : '0';
     const useSWserial = (document.getElementById("useSWserial").checked) ? '1' : '0';
     const obstFromStatus = (document.getElementById("obstFromStatus").checked) ? '1' : '0';
 
@@ -1267,6 +1283,7 @@ async function saveSettings() {
         "laserEnabled", laserEnabled,
         "laserHomeKit", laserHomeKit,
         "dcOpenClose", dcOpenClose,
+        "dcBypassTTC", dcBypassTTC,
         "assistDuration", assistDuration,
         "motionTriggers", motionTriggers,
         "occupancyDuration", occupancyDuration,

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -477,8 +477,15 @@
               <tr id="dcOpenCloseRow" style="display:none;">
                 <td></td>
                 <td>&nbsp;
-                  <input type="checkbox" id="dcOpenClose" name="dcOpenClose" value="no">
+                  <input type="checkbox" id="dcOpenClose" name="dcOpenClose" value="no" onclick="toggleHardwiredBypassRow()">
                   <label for="dcOpenClose">Enable hardwired open/close/light control</label>
+                </td>
+              </tr>
+              <tr id="dcBypassTTCRow" style="display:none;">
+                <td></td>
+                <td>&nbsp;
+                  <input type="checkbox" id="dcBypassTTC" name="dcBypassTTC" value="no">
+                  <label for="dcBypassTTC">Bypass time-to-close delay for hardwired controls</label>
                 </td>
               </tr>
               <tr id="useSWserialRow" style="display:none;">

--- a/src/www/status.json
+++ b/src/www/status.json
@@ -61,6 +61,7 @@
   "openDuration": 25,
   "closeDuration": 20,
   "dcOpenClose": false,
+  "dcBypassTTC": false,
   "useSWserial": true,
   "TTClight": true,
   "obstFromStatus": true,


### PR DESCRIPTION
…onal TTC Bypass


This PR fixes a long-standing mismatch between how Security+ 1.0/2.0 users expect hardwired open/close GPIOs to behave and how the firmware actually handled them. Users wiring these inputs like a real wall control expect true toggle semantics (toggle to move, pause, resume, or reverse) and do not expect the 5-second time-to-close warning that’s intended for remote-initiated closes. The firmware now treats simultaneous open+close presses as a genuine wall-station toggle, cancels any active TTC timers, and adds an optional, persistent setting to bypass the TTC delay for hardwired controls only. This option is documented in the README, exposed in the web UI when hardwired control is enabled, and ensures that physical wall-style inputs behave immediately and intuitively—while remotes and HomeKit continue to honor the configured TTC behavior.

Proposed upstream as well in: ratgdo/homekit-ratgdo32#136

**Problem:**

  Security+ 1.0/2.0 users wiring the open/close GPIOs for hardwired control expect wall-panel behavior (toggle to reverse,
  pause, resume) and the ability to bypass the 5‑second TTC warning that’s only meant for remote closings, but the firmware
  always honored TTC and didn’t document the toggle behavior clearly.

**Solution:**
  Treat simultaneous open+close presses as a real wall-station toggle, allow hardwired toggles/closes to skip TTC via a new
  configuration flag, and surface/document the option in the UI and README.

**Changes/Updates:**
  - Added detailed README guidance explaining that jumpering the open/close GPIOs mimics a factory wall control and describing the new TTC bypass option.
  - Implemented true toggle semantics in drycontact.cpp/comms.cpp, including cancellation of active TTC timers and optional bypassing of the warning delay for hardwired toggles and close-only presses.
  - Introduced the persistent dcBypassTTC setting (config keys/getter, status JSON, request handling) and wired it through the firmware logic.
  - Extended the web UI (HTML + JS) with a “Bypass time-to-close delay for hardwired controls” checkbox that only appears when hardwired control is enabled, and ensured it is saved/restored via setGDO.

**Expected Behavior:**
When hardwired control is enabled for Sec+ 1/2 GDO, tying the open/close GPIOs together behaves exactly like   the native wall switch. Specifically, idle toggles move the door in the opposite direction, toggles while moving pause the door, and the next toggle reverses direction. If the TTC bypass box is checked in webui, those hardwired toggles or close-only inputs act immediately without the 5- second flashing/beeping delay, while HomeKit/remotes continue to honor the configured TTC value.